### PR TITLE
Update script for OS X 10.11

### DIFF
--- a/cycleMacs.sh
+++ b/cycleMacs.sh
@@ -13,14 +13,17 @@ fi
 #Assign a default value if the network adapter name is missing
 adapter=${2-en0}
 
-osMinorVersion=$(sw_vers -productVersion | awk -F'.' '{ print $2 }')
+# This doesnt work since OSX 10.11 because of System Integrity Protection - there is no way to enable and disable Internet Sharing automatically
+# You need to enable it before launching this script
 
-if [ $(echo "$osMinorVersion < 10" | bc) -eq 0 ]
-		then
-			icsPlist='/System/Library/LaunchDaemons/com.apple.NetworkSharing.plist'
-		else
-			icsPlist='/System/Library/LaunchDaemons/com.apple.InternetSharing.plist'
-fi
+#osMinorVersion=$(sw_vers -productVersion | awk -F'.' '{ print $2 }')
+
+#if [ $(echo "$osMinorVersion < 10" | bc) -eq 0 ]
+#		then
+#			icsPlist='/System/Library/LaunchDaemons/com.apple.NetworkSharing.plist'
+#		else
+#			icsPlist='/System/Library/LaunchDaemons/com.apple.InternetSharing.plist'
+#fi
 
 #Check the number of arguments and confirm with user if they are correct
 if [ $# -lt 1 ]
@@ -30,18 +33,18 @@ if [ $# -lt 1 ]
 			while IFS=, read mac; do
 			echo "Setting mac address to $mac"	
 			ifconfig $adapter ether $mac
-			echo "Disabling ICS and sleeping for 10s"
-			sudo launchctl unload -w $icsPlist
-			sleep 10
+#			echo "Disabling ICS and sleeping for 10s"
+#			sudo launchctl unload -w $icsPlist
+#			sleep 10
 			echo "Disabling adapter and sleeping for 10s"
 			networksetup -setairportpower $adapter off
 			sleep 10
-			echo "Enabling adapter and sleeping for 10s"
+			echo "Enabling adapter and sleeping for 5 minutes"
 			networksetup -setairportpower $adapter on
-			sleep 10
-			echo "Enabling ICS and sleeping for 5 minutes"
-			sudo launchctl load -w $icsPlist
 			sleep 300
+#			echo "Enabling ICS and sleeping for 5 minutes"
+#			sudo launchctl load -w $icsPlist
+#			sleep 300
 			done <$1
 fi
 


### PR DESCRIPTION
Info: we can no longer load/unload com.apple.NetworkSharing.plist to
enable/disable Internet Sharing because of SIP.
